### PR TITLE
Disable nextjs image optimizations

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -2,7 +2,7 @@ module.exports = {
   output: 'standalone',
   reactStrictMode: true,
   images: {
-    unoptimized: false,
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Images are already behind cloudfront CDN and have multiple sizes